### PR TITLE
Fix missing using

### DIFF
--- a/Samples/PlaygroundSamples/Scripts/Module/BasicDashModule.cs
+++ b/Samples/PlaygroundSamples/Scripts/Module/BasicDashModule.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using DYP.Util;
 
 namespace DYP
 {


### PR DESCRIPTION
Assets\Samples\PlaygroundSamples\Scripts\Module\BasicDashModule.cs(37,16): error CS0246: The type or namespace name 'EasingFunction' could not be found (are you missing a using directive or an assembly reference?)